### PR TITLE
feat: add selectable PayDo payment methods with checkout & blocks sup…

### DIFF
--- a/includes/settings-paydo.php
+++ b/includes/settings-paydo.php
@@ -2,7 +2,7 @@
 /**
  * Settings for Paydo Standard Gateway.
  *
- * @version 1.0.0
+ * @version 1.1.0
  */
 
 if (!defined('ABSPATH')) {
@@ -11,56 +11,89 @@ if (!defined('ABSPATH')) {
 
 return [
 	'enabled' => [
-		'title' => __('Enable PayDo payments', 'paydo-woocommerce'),
-		'type' => 'checkbox',
-		'label' => __('Enable/Disable', 'paydo-woocommerce'),
-		'default' => 'yes',
+		'title'   => __('Enable/Disable', 'paydo-woocommerce'),
+		'type'    => 'checkbox',
+		'label'   => __('Enable PayDo', 'paydo-woocommerce'),
+		'default' => 'no',
 	],
+
 	'title' => [
-		'title' => __('Name of payment gateway', 'paydo-woocommerce'),
-		'type' => 'text',
-		'description' => __('The name of the payment gateway that the user see when placing the order', 'paydo-woocommerce'),
-		'default' => __('PayDo', 'paydo-woocommerce'),
+		'title'       => __('Title', 'paydo-woocommerce'),
+		'type'        => 'text',
+		'description' => __('This controls the title which the user sees during checkout.', 'paydo-woocommerce'),
+		'default'     => __('PayDo', 'paydo-woocommerce'),
+		'desc_tip'    => true,
 	],
-	'public_key' => [
-		'title' => __('Public key', 'paydo-woocommerce'),
-		'type' => 'text',
-		'description' => __('Issued in the client panel https://paydo.com', 'paydo-woocommerce'),
-		'default' => '',
-	],
-	'secret_key' => [
-		'title' => __('Secret key', 'paydo-woocommerce'),
-		'type' => 'text',
-		'description' => __('Issued in the client panel https://paydo.com', 'paydo-woocommerce'),
-		'default' => '',
-	],
+
 	'description' => [
-		'title' => __('Description', 'paydo-woocommerce'),
-		'type' => 'textarea',
-		'description' => __(
-			'Description of the payment gateway that the client will see on your site.',
-			'paydo-woocommerce'
-		),
-		'default' => __('Accept online payments using PayDo.com', 'paydo-woocommerce'),
+		'title'       => __('Description', 'paydo-woocommerce'),
+		'type'        => 'textarea',
+		'description' => __('Payment method description that the customer will see on your checkout.', 'paydo-woocommerce'),
+		'default'     => __('Pay securely via PayDo.', 'paydo-woocommerce'),
 	],
-	'auto_complete' => [
-		'title' => __('Order completion', 'paydo-woocommerce'),
-		'type' => 'checkbox',
-		'label' => __(
-			'Automatic transfer of the order to the status "Completed" after successful payment',
-			'paydo-woocommerce'
-		),
-		'description' => __('', 'paydo-woocommerce'),
-		'default' => '1',
+
+	'public_key' => [
+		'title'       => __('Public Key', 'paydo-woocommerce'),
+		'type'        => 'text',
+		'default'     => '',
 	],
+
+	'secret_key' => [
+		'title'       => __('Secret Key', 'paydo-woocommerce'),
+		'type'        => 'password',
+		'default'     => '',
+	],
+
 	'skip_confirm' => [
-		'title' => __('Skip confirmation', 'paydo-woocommerce'),
-		'type' => 'checkbox',
-		'label' => __(
-			'Skip page checkout confirmation',
-			'paydo-woocommerce'
-		),
-		'description' => __('', 'paydo-woocommerce'),
-		'default' => 'yes',
+		'title'   => __('Skip confirm step', 'paydo-woocommerce'),
+		'type'    => 'checkbox',
+		'label'   => __('Redirect customer to PayDo immediately', 'paydo-woocommerce'),
+		'default' => 'no',
+	],
+
+	'auto_complete' => [
+		'title'   => __('Auto-complete order', 'paydo-woocommerce'),
+		'type'    => 'checkbox',
+		'label'   => __('Mark order as completed after successful payment', 'paydo-woocommerce'),
+		'default' => 'no',
+	],
+
+	// --- Methods mode ---
+	'methods_mode' => [
+		'title'       => __('Payment methods selection', 'paydo-woocommerce'),
+		'type'        => 'checkbox',
+		'label'       => __('Let customer choose PayDo method on checkout', 'paydo-woocommerce'),
+		'default'     => 'no',
+		'description' => __('If enabled, customer must pick a PayDo method (from enabled list) during checkout.', 'paydo-woocommerce'),
+	],
+
+	'project_id' => [
+		'title'       => __('Project ID', 'paydo-woocommerce'),
+		'type'        => 'text',
+		'default'     => '',
+		'description' => __('Used for syncing available methods from PayDo.', 'paydo-woocommerce'),
+	],
+
+	'jwt_token' => [
+		'title'       => __('JWT Token', 'paydo-woocommerce'),
+		'type'        => 'textarea',
+		'default'     => '',
+		'description' => __('Bearer token for PayDo API (methods sync).', 'paydo-woocommerce'),
+	],
+
+	// Sync button (custom field type)
+	'sync_methods' => [
+		'title'       => __('Sync payment methods', 'paydo-woocommerce'),
+		'type'        => 'paydo_sync_methods',
+		'description' => __('Fetch available methods from PayDo and update list below.', 'paydo-woocommerce'),
+	],
+
+	// checkbox list (custom field type)
+	'enabled_methods' => [
+		'title'       => __('Enabled PayDo methods', 'paydo-woocommerce'),
+		'type'        => 'paydo_methods_checkboxes',
+		'description' => __('Select which methods can be used on checkout.', 'paydo-woocommerce'),
+		'default'     => [],
+		'options'     => [], // fill in init_form_fields()
 	],
 ];

--- a/js/admin-settings.js
+++ b/js/admin-settings.js
@@ -1,0 +1,29 @@
+(function ($) {
+	function togglePaydoMethodsFields() {
+		const mode = $('#woocommerce_paydo_methods_mode').is(':checked');
+
+		const ids = [
+			'#woocommerce_paydo_project_id',
+			'#woocommerce_paydo_jwt_token',
+			'#paydo-methods-search',
+			'#woocommerce_paydo_sync_methods',
+		];
+
+		ids.forEach((sel) => {
+			const $row = $(sel).closest('tr');
+			mode ? $row.show() : $row.hide();
+		});
+
+		const $syncRow = $('#paydo-sync-methods-btn').closest('tr');
+		mode ? $syncRow.show() : $syncRow.hide();
+
+		const $titleRow = $('.wc_settings_divider, h2').filter(function () {
+			return $(this).text().trim().toLowerCase().includes('payment methods');
+		}).closest('tr');
+	}
+
+	$(document).ready(function () {
+		togglePaydoMethodsFields();
+		$(document).on('change', '#woocommerce_paydo_methods_mode', togglePaydoMethodsFields);
+	});
+})(jQuery);

--- a/js/paydo-blocks-integration.js
+++ b/js/paydo-blocks-integration.js
@@ -1,33 +1,135 @@
-// Get payment method settings
-const settings = window.wc.wcSettings.getSetting('paydo_data', {});
+const settings = window.wc?.wcSettings?.getSetting('paydo_data', {}) || {};
+const { decodeEntities } = window.wp.htmlEntities;
+const { __ } = window.wp.i18n;
+const { createElement, useState, useEffect, Fragment } = window.wp.element;
 
-// Decode the label with localization consideration
-const label = window.wp.htmlEntities.decodeEntities(settings.title) || window.wp.i18n.__('Paydo', 'paydo-woocommerce');
+const label = decodeEntities(settings.title) || __('PayDo', 'paydo-woocommerce');
 
-// Payment Gateway Name
-const blockName = paydoBlockData.name;
+const methodsMode = !!settings.methods_mode;
+const available = settings.available_methods || {};
+const enabled = (settings.enabled_methods || []).map(String).filter(Boolean);
 
-// Function to get decoded content
-const Content = () => {
-	return window.wp.htmlEntities.decodeEntities(settings.description || '');
+const Content = (props) => {
+	const description = decodeEntities(settings.description || '');
+
+	const [selected, setSelected] = useState(enabled[0] || '');
+
+	useEffect(() => {
+		if (!props || !props.eventRegistration || !props.emitResponse) return;
+
+		const unsubscribe = props.eventRegistration.onPaymentSetup(async () => {
+			return {
+				type: props.emitResponse.responseTypes.SUCCESS,
+				meta: {
+					paymentMethodData: {
+						paydo_method: selected || '',
+					},
+				},
+			};
+		});
+
+		return unsubscribe;
+	}, [props, selected]);
+
+	const list = enabled
+		.map((id) => {
+			const item = available[id];
+
+			if (item && typeof item === 'object') {
+				return {
+					id,
+					title: item.title || `Method #${id}`,
+					logo: item.logo || '',
+				};
+			}
+
+			return {
+				id,
+				title: item || `Method #${id}`,
+				logo: '',
+			};
+		})
+		.filter((m) => m.id);
+
+	if (!methodsMode || !list.length) {
+		return createElement(
+			Fragment,
+			null,
+			description ? createElement('p', null, description) : null
+		);
+	}
+
+	return createElement(
+		Fragment,
+		null,
+		description ? createElement('p', null, description) : null,
+
+		createElement(
+			'div',
+			{ style: { marginTop: '10px' } },
+			createElement('strong', null, __('Choose PayDo method:', 'paydo-woocommerce')),
+
+			list.map((m) =>
+				createElement(
+					'label',
+					{
+						key: m.id,
+						style: {
+							display: 'flex',
+							alignItems: 'center',
+							gap: '10px',
+							padding: '8px 10px',
+							margin: '6px 0',
+							border: '1px solid rgba(0,0,0,.12)',
+							borderRadius: '10px',
+							cursor: 'pointer',
+							userSelect: 'none',
+						},
+					},
+					createElement('input', {
+						type: 'radio',
+						name: 'paydo_method',
+						value: m.id,
+						checked: selected === m.id,
+						onChange: () => setSelected(m.id),
+						style: { margin: 0 },
+					}),
+					m.logo
+						? createElement('img', {
+								src: m.logo,
+								alt: '',
+								loading: 'lazy',
+								style: {
+									height: '22px',
+									width: 'auto',
+									maxWidth: '60px',
+									objectFit: 'contain',
+								},
+						  })
+						: null,
+					createElement(
+						'span',
+						{ style: { lineHeight: 1.2 } },
+						decodeEntities(m.title)
+					)
+				)
+			)
+		)
+	);
 };
 
-// Payment method block definition
 const Block_Gateway = {
-	name: blockName,
-	label: label,
-	content: Object( window.wp.element.createElement )( Content, null ),
-	edit: Object( window.wp.element.createElement )( Content, null ),
-
-	// Function to check if payment can be made
-	canMakePayment() {
-		return true;
-	},
-
+	name: 'paydo',
+	label,
+	content: createElement(Content, null),
+	edit: createElement(Content, null),
+	canMakePayment: () => true,
 	ariaLabel: label,
+	supports: {
+		features: ['products'],
+	},
 };
 
-// Register the block if wcBlocksRegistry is defined
-if (window.wc.wcBlocksRegistry) {
+if (window.wc?.wcBlocksRegistry) {
 	window.wc.wcBlocksRegistry.registerPaymentMethod(Block_Gateway);
 }

--- a/paydo.php
+++ b/paydo.php
@@ -4,12 +4,12 @@ Plugin Name: PayDo WooCommerce Payment Gateway
 Plugin URI: https://github.com/PaydoW/woocommerce-plugin
 Description: PayDo: Online payment processing service ➦ Accept payments online by 150+ methods from 170+ countries. Payments gateway for Growing Your Business in New Locations and fast online payments
 Author URI: https://paydo.com/
-Version: 2.1.0
+Version: 2.2.0
 Requires at least: 6.3
-Tested up to: 6.8.2
+Tested up to: 6.9
 Requires PHP: 7.4
 WC requires at least: 8.3
-WC tested up to: 10.0.4
+WC tested up to: 10.4.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,12 @@
 ﻿=== PayDo Official ===
 Tags: credit cards, payment methods, paydo, payment gateway
-Version: 2.1.0
-Stable tag: 2.1.0
+Version: 2.2.0
+Stable tag: 2.2.0
 Requires at least: 6.3
-Tested up to: 6.8.2
+Tested up to: 6.9
 Requires PHP: 7.4
 WC requires at least: 8.3
-WC tested up to: 10.0.4
+WC tested up to: 10.4.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -75,3 +75,17 @@ Use below parameters to configure your PayDo project:
 * Added: WordPress 6.8.x Compatibility
 * Added: WooCommerce 10.x.x Compatibility
 * Fixed: Improved behavior when navigating back from the payment page — users are now correctly redirected to the WooCommerce checkout instead of encountering a broken or expired order page.
+
+= 2.2.0 = (February 2, 2026)
+
+* Added: Ability to sync available payment methods directly from PayDo API
+* Added: Manual selection of enabled PayDo payment methods in WooCommerce settings
+* Added: Display of selected PayDo payment methods on Classic Checkout (radio list)
+* Added: Display of selected PayDo payment methods on Checkout Blocks (Gutenberg)
+* Added: Support for passing selected PayDo payment method to the invoice creation API
+* Added: WordPress 6.9.x Compatibility
+* Improved: Admin UI for payment methods selection (searchable checkbox list)
+* Improved: Reuse of existing WooCommerce gateway instance in Blocks integration
+* Improved: Better validation when payment method selection is enabled
+* Fixed: Issue where payment methods were not displayed on the checkout page
+* Fixed: Inconsistent behavior between Classic Checkout and Checkout Blocks


### PR DESCRIPTION
…port

- add PayDo API sync for available payment methods
- allow merchants to select enabled methods in gateway settings
- render selected methods on Classic Checkout (radio list with logos)
- render selected methods on Checkout Blocks (Gutenberg)
- pass selected payment method to invoice creation API
- reuse existing WooCommerce gateway instance in Blocks integration
- improve admin UI for methods selection (searchable list)
- fix missing methods on checkout page